### PR TITLE
Add Minimig Control Board

### DIFF
--- a/src/identify/ID_Database.s
+++ b/src/identify/ID_Database.s
@@ -1506,6 +1506,7 @@ manuf_tab	tabinit
 
 		manuf	05017,"Alastair M. Robinson"
 		board	  017,"Minimig Z3 FastRAM",	MSG_EXP_RAM
+		board	  018,"Minimig Control Board",	MSG_EXP_MISC
 		endmf	05017
 
 		manuf	05018,"Austex Software"


### PR DESCRIPTION
This PR adds the [Minimig Control Board](https://github.com/minimig-dev/MinimigAGA-MiST-TC64/blob/master/rtl/minimig/minimig_autoconfig_rom.v#L113) of the MinimigAGA-MiST-TC64 project.

`ListExp WIDE`: [identify_listexp_wide_5017_18.txt](https://github.com/user-attachments/files/18565300/identify_listexp_wide_5017_18.txt)

